### PR TITLE
feat: allow migrations glob customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ This library uses [`umzug`'s CLI](https://github.com/sequelize/umzug#cli-usage) 
 ```sh
 npx migrate-contentful -h
 ```
+
+## Customising migration paths
+
+The default migrations folder is `migrations/scripts`
+
+When creating a migration, you can use the `--folder` flag to specify a custom folder to look for migrations in.
+```
+npx migrate-contentful --folder <path>
+``` 
+
+When running a migration `npx create-contentful-migration up`, should pass a `--glob` flag pointing to your custom folder.
+```
+npx migrate-contentful up --glob my-custom-folder/*.ext
+```
+
 ## Contributing
 
 Contributions welcome!

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The default migrations folder is `migrations/scripts`
 
 When creating a migration, you can use the `--folder` flag to specify a custom folder to look for migrations in.
 ```
-npx migrate-contentful --folder <path>
+npx migrate-contentful create --folder <path> --name <name>
 ``` 
 
 When running a migration `npx create-contentful-migration up`, should pass a `--glob` flag pointing to your custom folder.

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -29,6 +29,9 @@ async function migrate(migrationFunction: MigrationFunction): Promise<void> {
 const args = process.argv.slice(2);
 const globIndex = args.findIndex(arg => arg === '--glob');
 const glob = globIndex !== -1 ? args[globIndex + 1] : `${process.cwd()}/migrations/scripts/*.ts`;
+if (globIndex !== -1) {
+  process.argv.splice(2 + globIndex, 2);
+}
 
 const umzug = new Umzug({
   migrations: { glob },

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -26,8 +26,12 @@ async function migrate(migrationFunction: MigrationFunction): Promise<void> {
   });
 }
 
+const args = process.argv.slice(2);
+const globIndex = args.findIndex(arg => arg === '--glob');
+const glob = globIndex !== -1 ? args[globIndex + 1] : `${process.cwd()}/migrations/scripts/*.ts`;
+
 const umzug = new Umzug({
-  migrations: { glob: `${process.cwd()}/migrations/scripts/*.ts` },
+  migrations: { glob },
   storage: new ContentfulStorage({
     spaceId: process.env.CONTENTFUL_SPACE_ID,
     environmentId: process.env.CONTENTFUL_ENVIRONMENT,


### PR DESCRIPTION
When using the `--folder` arg, there's no way to let this package know your migrations are in a different place.

This PR allows glob customisation for migrations location